### PR TITLE
Create tutorial-style Next.js starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
+# Next.js Tutorial Starter
 
+This project is a custom scaffolded Next.js application that mirrors the output of `create-next-app` while adding a documentation-style layout:
+
+- Chapter navigation in the header
+- Subchapter navigation in a sticky sidebar
+- Content sourced from Markdown (`.md`) and MDX (`.mdx`) files
+
+## Getting Started
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Run the development server
+   ```bash
+   npm run dev
+   ```
+3. Open [http://localhost:3000](http://localhost:3000) to view the tutorial.
+
+The home route redirects to the first available chapter. Update the entries in `lib/chapters.ts` and add new files in the `content/` directory to expand the curriculum.

--- a/app/[chapter]/[subchapter]/page.tsx
+++ b/app/[chapter]/[subchapter]/page.tsx
@@ -1,0 +1,41 @@
+import { notFound } from "next/navigation";
+import { flattenSubchapters, getSubchapter } from "@/lib/chapters";
+
+export function generateStaticParams() {
+  return flattenSubchapters();
+}
+
+type PageProps = {
+  params: {
+    chapter: string;
+    subchapter: string;
+  };
+};
+
+export async function generateMetadata({ params }: PageProps) {
+  const result = getSubchapter(params.chapter, params.subchapter);
+  if (!result) {
+    return {};
+  }
+
+  return {
+    title: `${result.subchapter.title} — ${result.chapter.title}`,
+    description: result.chapter.description,
+  };
+}
+
+export default async function SubchapterPage({ params }: PageProps) {
+  const result = getSubchapter(params.chapter, params.subchapter);
+  if (!result) {
+    notFound();
+  }
+
+  const { subchapter } = result;
+  const Content = (await subchapter.import()).default;
+
+  return (
+    <article>
+      <Content />
+    </article>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,165 @@
+:root {
+  color-scheme: light dark;
+  --background: #0b1120;
+  --surface: rgba(15, 23, 42, 0.6);
+  --surface-light: rgba(148, 163, 184, 0.18);
+  --border: rgba(148, 163, 184, 0.35);
+  --text-primary: #e2e8f0;
+  --text-secondary: #94a3b8;
+  --accent: #38bdf8;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, rgba(56, 189, 248, 0.2), transparent 50%),
+    radial-gradient(circle at bottom, rgba(129, 140, 248, 0.25), transparent 40%),
+    var(--background);
+  color: var(--text-primary);
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.app-container {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(16px);
+  background-color: rgba(15, 23, 42, 0.65);
+  border-bottom: 1px solid var(--border);
+}
+
+.header nav {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 2rem;
+}
+
+.header a {
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.header a.active {
+  background-color: rgba(56, 189, 248, 0.15);
+  color: var(--text-primary);
+  border: 1px solid rgba(56, 189, 248, 0.4);
+}
+
+.header a:hover {
+  color: var(--text-primary);
+}
+
+.content-wrapper {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) 1fr;
+  flex: 1;
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+  padding: 2rem;
+  gap: 2rem;
+}
+
+.sidebar {
+  position: sticky;
+  top: 5.5rem;
+  align-self: flex-start;
+  padding: 1.5rem 1.25rem;
+  border-radius: 1rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.sidebar h2 {
+  margin: 0 0 0.75rem;
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+}
+
+.sidebar a {
+  padding: 0.45rem 0.65rem;
+  border-radius: 0.6rem;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.sidebar a.active {
+  background-color: rgba(56, 189, 248, 0.2);
+  color: var(--text-primary);
+}
+
+main {
+  padding: 2rem;
+  border-radius: 1.25rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.45);
+}
+
+article {
+  max-width: 700px;
+  margin: 0 auto;
+  line-height: 1.7;
+  color: var(--text-secondary);
+}
+
+article h1,
+article h2,
+article h3 {
+  color: var(--text-primary);
+}
+
+article code {
+  background-color: rgba(15, 23, 42, 0.95);
+  border-radius: 0.35rem;
+  padding: 0.2rem 0.4rem;
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+}
+
+@media (max-width: 900px) {
+  .content-wrapper {
+    grid-template-columns: 1fr;
+    padding: 1.5rem;
+  }
+
+  .sidebar {
+    position: relative;
+    top: auto;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  main {
+    padding: 1.5rem;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { Inter } from "next/font/google";
+import "./globals.css";
+import HeaderNav from "@/components/HeaderNav";
+import Sidebar from "@/components/Sidebar";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: {
+    default: "Next.js Tutorial",
+    template: "%s • Next.js Tutorial",
+  },
+  description:
+    "A learning environment with chapters and subchapters rendered from Markdown and MDX.",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>
+        <div className="app-container">
+          <HeaderNav />
+          <div className="content-wrapper">
+            <Sidebar />
+            <main>{children}</main>
+          </div>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from "next/navigation";
+import { chapters, getChapterHref } from "@/lib/chapters";
+
+export default function HomePage() {
+  if (chapters.length === 0) {
+    return null;
+  }
+
+  redirect(getChapterHref(chapters[0].slug));
+}

--- a/components/HeaderNav.tsx
+++ b/components/HeaderNav.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { chapters, getChapterHref } from "@/lib/chapters";
+
+export default function HeaderNav() {
+  const pathname = usePathname();
+
+  return (
+    <header className="header">
+      <nav aria-label="Chapter navigation">
+        {chapters.map((chapter) => {
+          const href = getChapterHref(chapter.slug);
+          const isActive = pathname.startsWith(`/${chapter.slug}`);
+          return (
+            <Link
+              key={chapter.slug}
+              href={href}
+              className={isActive ? "active" : undefined}
+            >
+              {chapter.title}
+            </Link>
+          );
+        })}
+      </nav>
+    </header>
+  );
+}

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { chapters } from "@/lib/chapters";
+
+export default function Sidebar() {
+  const pathname = usePathname();
+  const [_, chapterSlug, subchapterSlug] = pathname.split("/");
+  const currentChapter = chapters.find((chapter) => chapter.slug === chapterSlug);
+
+  if (!currentChapter) {
+    return null;
+  }
+
+  return (
+    <aside className="sidebar" aria-label="Subchapter navigation">
+      <h2>{currentChapter.title}</h2>
+      {currentChapter.subchapters.map((subchapter) => {
+        const href = `/${currentChapter.slug}/${subchapter.slug}`;
+        const isActive = subchapter.slug === subchapterSlug;
+        return (
+          <Link key={subchapter.slug} href={href} className={isActive ? "active" : undefined}>
+            {subchapter.title}
+          </Link>
+        );
+      })}
+    </aside>
+  );
+}

--- a/content/core-concepts/app-router.mdx
+++ b/content/core-concepts/app-router.mdx
@@ -1,0 +1,12 @@
+# App Router Overview
+
+The **App Router** embraces React Server Components, layouts, and nested routing in a way that feels natural. Each folder inside `app/` becomes part of the URL, while `layout.tsx` files let you compose persistent UI like the navigation used in this tutorial.
+
+```tsx
+// app/example/page.tsx
+export default function ExamplePage() {
+  return <h1>Hello from the App Router!</h1>;
+}
+```
+
+Layouts can fetch data, stream UI, and share loading states across entire sections of your site. They are the foundation for rich application shells.

--- a/content/core-concepts/data-fetching.md
+++ b/content/core-concepts/data-fetching.md
@@ -1,0 +1,9 @@
+# Data Fetching Patterns
+
+Next.js simplifies data requirements with Route Handlers, Server Actions, and `fetch` caching. Consider the following guidelines when planning your data layer:
+
+- Fetch data in server components whenever possible to keep bundles small.
+- Opt into caching by default, or mark fetches as `cache: "no-store"` when you need the freshest data.
+- Use loading UI (`loading.tsx`) to provide immediate feedback for slow requests.
+
+Combining these patterns with MDX-powered content helps you ship fast documentation sites and dashboards alike.

--- a/content/getting-started/introduction.mdx
+++ b/content/getting-started/introduction.mdx
@@ -1,0 +1,17 @@
+---
+title: Introduction to the Tutorial
+---
+
+# Welcome to the Next.js Tutorial
+
+In this learning path you will explore how **Next.js** blends the best features of React with a powerful full-stack platform. Each chapter is intentionally short and focuses on a single idea so you can progress quickly.
+
+> Tip: Use the chapter navigation above to jump to major milestones, and the sidebar on the left to switch between subchapters.
+
+By the end of this journey you will know how to:
+
+- scaffold a project with sensible defaults
+- understand the _App Router_ mental model
+- load content from Markdown and MDX sources
+
+Ready to begin? Continue with the project setup guide in the next section.

--- a/content/getting-started/project-setup.md
+++ b/content/getting-started/project-setup.md
@@ -1,0 +1,11 @@
+# Project Setup
+
+Creating a new project is usually as simple as running `npx create-next-app@latest` and answering a few prompts. The generator configures TypeScript, ESLint, and a modern `app/` directory so you can focus on building features rather than scaffolding.
+
+Even without internet access you can mimic the generated structure manually. The important bits include:
+
+1. `package.json` with Next.js, React, and TypeScript dependencies
+2. a `next.config.mjs` file so the framework understands how to build the app
+3. the `app/` directory containing layouts, routes, and global styles
+
+Once dependencies are installed, run `npm run dev` to launch the development server on [http://localhost:3000](http://localhost:3000).

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,5 @@
+import nextConfig from "eslint-config-next";
+
+export default [
+  ...nextConfig(),
+];

--- a/lib/chapters.ts
+++ b/lib/chapters.ts
@@ -1,0 +1,85 @@
+import type { ComponentType } from "react";
+
+export type ContentModule = {
+  default: ComponentType;
+};
+
+type Subchapter = {
+  slug: string;
+  title: string;
+  import: () => Promise<ContentModule>;
+};
+
+type Chapter = {
+  slug: string;
+  title: string;
+  description: string;
+  subchapters: Subchapter[];
+};
+
+export const chapters: Chapter[] = [
+  {
+    slug: "getting-started",
+    title: "Getting Started",
+    description: "Lay the foundation for your Next.js learning journey.",
+    subchapters: [
+      {
+        slug: "introduction",
+        title: "Introduction",
+        import: () => import("@/content/getting-started/introduction.mdx"),
+      },
+      {
+        slug: "project-setup",
+        title: "Project Setup",
+        import: () => import("@/content/getting-started/project-setup.md"),
+      },
+    ],
+  },
+  {
+    slug: "core-concepts",
+    title: "Core Concepts",
+    description: "Discover the building blocks that power every application.",
+    subchapters: [
+      {
+        slug: "app-router",
+        title: "App Router",
+        import: () => import("@/content/core-concepts/app-router.mdx"),
+      },
+      {
+        slug: "data-fetching",
+        title: "Data Fetching",
+        import: () => import("@/content/core-concepts/data-fetching.md"),
+      },
+    ],
+  },
+];
+
+export function getChapterHref(slug: string) {
+  const chapter = chapters.find((chapter) => chapter.slug === slug);
+  if (!chapter) {
+    return "/";
+  }
+  const firstSubchapter = chapter.subchapters[0];
+  return `/${chapter.slug}/${firstSubchapter.slug}`;
+}
+
+export function getSubchapter(chapterSlug: string, subchapterSlug: string) {
+  const chapter = chapters.find((chapter) => chapter.slug === chapterSlug);
+  if (!chapter) {
+    return undefined;
+  }
+  const subchapter = chapter.subchapters.find((entry) => entry.slug === subchapterSlug);
+  if (!subchapter) {
+    return undefined;
+  }
+  return { chapter, subchapter } as const;
+}
+
+export function flattenSubchapters() {
+  return chapters.flatMap((chapter) =>
+    chapter.subchapters.map((subchapter) => ({
+      chapterSlug: chapter.slug,
+      subchapterSlug: subchapter.slug,
+    }))
+  );
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,14 @@
+import createMDX from '@next/mdx';
+
+const withMDX = createMDX({
+  extension: /\.mdx?$/,
+});
+
+const nextConfig = withMDX({
+  experimental: {
+    mdxRs: true,
+  },
+  pageExtensions: ['ts', 'tsx', 'md', 'mdx'],
+});
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "tutorial-next-js",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@next/mdx": "14.2.5",
+    "@types/node": "20.11.30",
+    "@types/react": "18.2.57",
+    "@types/react-dom": "18.2.19",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.5",
+    "typescript": "5.4.5"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.md", "**/*.mdx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js starter project configured with MDX support and TypeScript tooling
- implement shared layout with chapter header navigation and contextual sidebar
- add initial Markdown and MDX content files for tutorial chapters and subchapters

## Testing
- not run (package installation unavailable in this offline environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4c53d672c8328999e54e7dc114c61