### PR TITLE
Add MDX components bridge to fix MDX imports

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,0 +1,7 @@
+import type { MDXComponents } from "mdx/types";
+
+export function useMDXComponents(components: MDXComponents): MDXComponents {
+  return {
+    ...components,
+  };
+}


### PR DESCRIPTION
## Summary
- add an mdx-components.tsx bridge so Next.js can resolve useMDXComponents when loading MDX content

## Testing
- npm run lint *(fails: Next CLI unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4ca2e1d388328b04b87222e15f1c7