### PR TITLE
Add TypeScript declarations for MDX content

### DIFF
--- a/mdx.d.ts
+++ b/mdx.d.ts
@@ -1,0 +1,11 @@
+import type { MDXContentProps } from "mdx/types";
+
+declare module "*.mdx" {
+  let MDXComponent: (props: MDXContentProps) => JSX.Element;
+  export default MDXComponent;
+}
+
+declare module "*.md" {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary
- add TypeScript module declarations so MDX and Markdown imports resolve during builds

## Testing
- npm run build *(fails: Next.js cannot download Inter font in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4cb4ecb0483289300ed681f17ba3b