### PR TITLE
Replace language dropdown with flag icons

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -57,6 +57,38 @@ a:focus {
 }
 
 
+.language-switcher {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem 2rem 1rem 0;
+}
+
+
+.language-switcher__button {
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: 1.5rem;
+  line-height: 1;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+  opacity: 0.6;
+}
+
+
+.language-switcher__button[aria-pressed="true"] {
+  opacity: 1;
+}
+
+
+.language-switcher__button:hover,
+.language-switcher__button:focus-visible {
+  transform: translateY(-1px);
+  opacity: 1;
+  outline: none;
+}
+
+
 .header a {
   padding: 0.5rem 0.75rem;
   font-weight: 500;

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -3,10 +3,10 @@
 import { useRouter, usePathname } from 'next/navigation';
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES, isLocale, type Locale } from '@/lib/i18n';
 
-const LANGUAGE_LABELS: Record<Locale, string> = {
-  de: 'Deutsch',
-  en: 'English',
-  mr: 'मराठी',
+const LANGUAGE_META: Record<Locale, { label: string; flag: string }> = {
+  de: { label: 'Deutsch', flag: '🇩🇪' },
+  en: { label: 'English', flag: '🇺🇸' },
+  mr: { label: 'मराठी', flag: '🇮🇳' },
 };
 
 function getCurrentLocale(pathname: string): Locale {
@@ -23,9 +23,7 @@ export default function LanguageSwitcher() {
   const pathname = usePathname();
   const currentLocale = getCurrentLocale(pathname);
 
-  const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
-    const nextLocale = event.target.value as Locale;
-
+  const handleLocaleSelection = (nextLocale: Locale) => {
     if (nextLocale === currentLocale) {
       return;
     }
@@ -42,12 +40,27 @@ export default function LanguageSwitcher() {
   };
 
   return (
-    <select onChange={handleChange} value={currentLocale}>
-      {SUPPORTED_LOCALES.map((locale) => (
-        <option key={locale} value={locale}>
-          {LANGUAGE_LABELS[locale]}
-        </option>
-      ))}
-    </select>
+    <div className="language-switcher" role="group" aria-label="Sprachauswahl">
+      {SUPPORTED_LOCALES.map((locale) => {
+        const { label, flag } = LANGUAGE_META[locale];
+        const isActive = locale === currentLocale;
+
+        return (
+          <button
+            key={locale}
+            type="button"
+            onClick={() => handleLocaleSelection(locale)}
+            aria-pressed={isActive}
+            aria-label={label}
+            title={label}
+            className="language-switcher__button"
+          >
+            <span aria-hidden="true" role="img">
+              {flag}
+            </span>
+          </button>
+        );
+      })}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the language switcher dropdown with clickable flag buttons for each locale
- add styling for the new icon-based language selector in the header

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68e65ad338288328b5c8ea9774a72e0b